### PR TITLE
fix error: use of undeclared identifier 'PATH_MAX'

### DIFF
--- a/blkmv.c
+++ b/blkmv.c
@@ -23,6 +23,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <unistd.h>
 #include <sys/stat.h>
 
+#if defined(__APPLE__)
+#include <sys/syslimits.h>
+#else
+#include <linux/limits.h>
+#endif
+
 #define STB_DS_IMPLEMENTATION
 #include "ext/stb_ds.h"
 


### PR DESCRIPTION
This commit fixes the undeclared identifier error for Linux and macOS.

```console
$ cc blkmv.c -std=gnu99 -Wall -O2 -s -o r_blkmv
blkmv.c:220:20: error: use of undeclared identifier 'PATH_MAX'
                                char new_path [PATH_MAX];
                                               ^
...
12 errors generated.
make: *** [Makefile:16: r_blkmv] Error 1
```